### PR TITLE
Increased notification timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ host = "localhost"
 notification_strategy = "polling"
 # The rate at which the polling strategy refreshes notifications
 polling_rate = 250
+# The duration the notification shows up on screen
+timeout = 2
 ```
 
 https://user-images.githubusercontent.com/52386117/210190106-17c0cb01-8f35-4135-9db9-68f06e6400ec.mp4

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,9 @@ pub struct NotifierConfig {
     pub notification_strategy: NotificationStrategy,
     #[arg(long, default_value_t = 250)]
     pub polling_rate: u64,
+
+    #[arg(long, default_value_t = 2.0)]
+    pub timeout: f32,
 }
 
 impl Default for NotifierConfig {
@@ -31,6 +34,7 @@ impl Default for NotifierConfig {
             host: "localhost".into(),
             notification_strategy: NotificationStrategy::Listener,
             polling_rate: 250,
+            timeout: 2.0,
         }
     }
 }

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -6,3 +6,5 @@ host = "localhost"
 notification_strategy = "polling"
 # The rate at which the polling strategy refreshes notifications
 polling_rate = 250
+# The duration the notification shows up on screen
+timeout = 2

--- a/src/notif_handling.rs
+++ b/src/notif_handling.rs
@@ -39,7 +39,10 @@ async fn read_logo(display_info: AppDisplayInfo) -> anyhow::Result<Vec<u8>> {
         .context("failed to read stream to bytes")
 }
 
-pub async fn notif_to_message(notif: UserNotification) -> anyhow::Result<XSOverlayMessage> {
+pub async fn notif_to_message(
+    notif: UserNotification,
+    timeout: f32,
+) -> anyhow::Result<XSOverlayMessage> {
     let app_info = notif.AppInfo()?;
     let display_info = app_info.DisplayInfo()?;
     let app_name = display_info.DisplayName()?.to_string();
@@ -74,7 +77,7 @@ pub async fn notif_to_message(notif: UserNotification) -> anyhow::Result<XSOverl
     Ok(XSOverlayMessage {
         messageType: 1,
         index: 0,
-        timeout: 7,
+        timeout,
         height: 175.,
         opacity: 1.,
         volume: 0.7,
@@ -91,6 +94,7 @@ pub async fn polling_notification_handler(
     listener: UserNotificationListener,
     tx: &UnboundedSender<XSOverlayMessage>,
     polling_rate: u64,
+    timeout: f32,
 ) -> Result<()> {
     let mut prev_notifs: Option<Vec<UserNotification>> = None;
     loop {
@@ -107,7 +111,7 @@ pub async fn polling_notification_handler(
                     .is_none()
             }) {
                 log::info!("handling new notification");
-                let msg = notif_to_message(notif).await;
+                let msg = notif_to_message(notif, timeout).await;
                 match msg {
                     Ok(msg) => tx.send(msg)?,
                     Err(e) => println!("Failed to convert notification to XSOverlay message: {e}"),
@@ -122,6 +126,7 @@ pub async fn polling_notification_handler(
 pub async fn listening_notification_handler(
     listener: UserNotificationListener,
     tx: &UnboundedSender<XSOverlayMessage>,
+    timeout: f32,
 ) -> Result<()> {
     let (new_notif_tx, mut new_notif_rx) = unbounded_channel::<u32>();
     listener
@@ -145,7 +150,7 @@ pub async fn listening_notification_handler(
             let notif = listener
                 .GetNotification(notif_id)
                 .context(format!("failed to get notification {notif_id}"))?;
-            let msg = notif_to_message(notif).await;
+            let msg = notif_to_message(notif, timeout).await;
             match msg {
                 Ok(msg) => tx.send(msg)?,
                 Err(e) => println!("Failed to convert notification to XSOverlay message: {e}"),
@@ -180,9 +185,11 @@ pub async fn notification_listener(
     }
     info!("Notification access granted");
     match config.notification_strategy {
-        NotificationStrategy::Listener => listening_notification_handler(listener, tx).await,
+        NotificationStrategy::Listener => {
+            listening_notification_handler(listener, tx, config.timeout).await
+        }
         NotificationStrategy::Polling => {
-            polling_notification_handler(listener, tx, config.polling_rate).await
+            polling_notification_handler(listener, tx, config.polling_rate, config.timeout).await
         }
     }
 }

--- a/src/notif_handling.rs
+++ b/src/notif_handling.rs
@@ -74,7 +74,7 @@ pub async fn notif_to_message(notif: UserNotification) -> anyhow::Result<XSOverl
     Ok(XSOverlayMessage {
         messageType: 1,
         index: 0,
-        timeout: 0.5,
+        timeout: 7,
         height: 175.,
         opacity: 1.,
         volume: 0.7,


### PR DESCRIPTION
Increased the timeout for notifications to a recommended length of seven seconds. The previous timeout of half a second was far too short to even parse through notification messages.